### PR TITLE
Time of message to be relative from now, not to now.

### DIFF
--- a/src/pipes/relative-time.ts
+++ b/src/pipes/relative-time.ts
@@ -15,6 +15,6 @@ export class RelativeTime implements PipeTransform {
      * Takes a value and makes it lowercase.
      */
     transform(value: string, ...args) {
-        return moment(value).toNow();
+        return moment(value).fromNow();
     }
 }


### PR DESCRIPTION
Previous would return "in 6 months" where it should be "6 months ago".