### PR TITLE
corrected css for very long words (or sentenses without spaces)

### DIFF
--- a/src/pages/chat/chat.scss
+++ b/src/pages/chat/chat.scss
@@ -72,7 +72,7 @@ page-chat {
           border: 1px solid #ddd;
           color: #fff;
           width: auto;
-
+          max-width: 80%;
           span.triangle {
             background-color: #fff;
             border-radius: 2px;


### PR DESCRIPTION
Words like "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" goes out of the screen without this commit.
[nexus 6p](https://user-images.githubusercontent.com/22277943/32941573-2db270e4-cbac-11e7-9193-3ec47e8b41ee.png)
[nexus 6p 1](https://user-images.githubusercontent.com/22277943/32940427-a1c3e80e-cba8-11e7-9128-c483e3698b30.png)

